### PR TITLE
SUPASST-739 re-add toggleConversation, tame CSS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ module
 # Test files
 coverage
 rasa-webchat-*.tgz
+test/

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ module
 
 # Test files
 coverage
+rasa-webchat-*.tgz

--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
+# A Fork of `rasa-webchat` to use in the Support Assistant Chris
+
+This fork was created to restore the `toggleChat` function that was removed after the `0.6` version.
+
+## Usage
+
+Generate a package from this project, and follow instructions on the Support Assistant Project to update
+the package there.
+
+1. `npm i`
+2. `npm pack` - this will generate a `rasa-webchat-<version>.tgz` package that can be installed with NPM in the 
+  target project.
+3. copy `rasa-webchat-<version>.tgz` to the target project
+4. 
+
 <p align="center">
 
 <a href="https://www.npmjs.com/package/botfront">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rasa-webchat",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -16074,6 +16074,104 @@
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
       "dev": true
+    },
+    "mini-css-extract-plugin": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-1.6.2.tgz",
+      "integrity": "sha512-WhDvO3SjGm40oV5y26GjMJYjd2UMqrLAGKy5YS2/3QKJy2F7jgynuHTir/tgUUOiNQu5saXHdc8reo7YuhhT4Q==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0",
+        "webpack-sources": "^1.1.0"
+      },
+      "dependencies": {
+        "@types/json-schema": {
+          "version": "7.0.9",
+          "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
+          "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+          "dev": true
+        },
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-keywords": {
+          "version": "3.5.2",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+          "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+          "dev": true
+        },
+        "big.js": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+          "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+          "dev": true
+        },
+        "emojis-list": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+          "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+          "dev": true
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
+        },
+        "json5": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+          "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        },
+        "schema-utils": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+          "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.8",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
+          }
+        }
+      }
     },
     "minimalistic-assert": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rasa-webchat",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Chat web widget for React apps and Rasa Core chatbots",
   "module": "module/index.js",
   "main": "lib/index.js",
@@ -9,6 +9,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "dev": "webpack-dev-server --config webpack.dev.js",
+    "build-dev": "webpack --config webpack.dev.js -d",
     "build": "webpack --config webpack.prod.js -p",
     "test": "jest",
     "prepare": "npm run build",
@@ -95,10 +96,5 @@
       "\\.(css|scss)$": "<rootDir>/mocks/styleMock.js"
     },
     "setupTestFrameworkScriptFile": "<rootDir>/test-setup.js"
-  },
-  "husky": {
-    "hooks": {
-      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
-    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "husky": "^3.0.7",
     "jest": "^25.5.4",
     "lodash-webpack-plugin": "^0.11.5",
+    "mini-css-extract-plugin": "^1.6.2",
     "node-sass": "^4.12.0",
     "prettier": "^1.18.2",
     "prettier-eslint": "^5.1.0",

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -5,63 +5,65 @@ const path = require('path');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
 const { version } = require('./package.json');
 
-module.exports = [{
-  // entry: ['babel-polyfill', './index.js'],
-  entry: './umd.js',
-  output: {
-    path: path.join(__dirname, '/lib'),
-    filename: 'index.js',
-    library: 'WebChat',
-    libraryTarget: 'umd'
-  },
-  resolve: {
-    extensions: ['.js', '.jsx']
-  },
-  mode: 'production',
-  module: {
-    rules: [
-      {
-        test: /\.(js|jsx)$/,
-        exclude: /node_modules/,
-        use: [
-          {
-            loader: 'string-replace-loader',
-            options: {
-              search: 'PACKAGE_VERSION_TO_BE_REPLACED',
-              replace: version
-            }
-          },
-          { loader: 'babel-loader' }
-        ]
-      },
-      {
-        test: /\.scss$/,
-        use: [
-          { loader: 'style-loader' },
-          { loader: 'css-loader' },
-          {
-            loader: 'sass-loader',
-            options: {
-              includePaths: [path.resolve(__dirname, 'src/scss/')]
-            }
-          }
-        ]
-      },
-      {
-        test: /\.css$/,
-        use: ['style-loader', 'css-loader']
-      },
-      {
-        test: /\.(jpg|png|gif|svg|woff|ttf|eot)$/,
-        use: {
-          loader: 'url-loader'
-        }
-      }
-    ]
-  },
-  plugins: [new CleanWebpackPlugin(['lib'])]
-}, {
-  entry: './index.js',
+module.exports = [
+//   {
+//   // entry: ['babel-polyfill', './index.js'],
+//   entry: './index_for_react_app.js',
+//   output: {
+//     path: path.join(__dirname, '/lib'),
+//     filename: 'index.js',
+//     library: 'WebChat',
+//     libraryTarget: 'umd'
+//   },
+//   resolve: {
+//     extensions: ['.js', '.jsx']
+//   },
+//   mode: 'production',
+//   module: {
+//     rules: [
+//       {
+//         test: /\.(js|jsx)$/,
+//         exclude: /node_modules/,
+//         use: [
+//           {
+//             loader: 'string-replace-loader',
+//             options: {
+//               search: 'PACKAGE_VERSION_TO_BE_REPLACED',
+//               replace: version
+//             }
+//           },
+//           { loader: 'babel-loader' }
+//         ]
+//       },
+//       {
+//         test: /\.scss$/,
+//         use: [
+//           { loader: 'style-loader' },
+//           { loader: 'css-loader' },
+//           {
+//             loader: 'sass-loader',
+//             options: {
+//               includePaths: [path.resolve(__dirname, 'src/scss/')]
+//             }
+//           }
+//         ]
+//       },
+//       {
+//         test: /\.css$/,
+//         use: ['style-loader', 'css-loader']
+//       },
+//       {
+//         test: /\.(jpg|png|gif|svg|woff|ttf|eot)$/,
+//         use: {
+//           loader: 'url-loader'
+//         }
+//       }
+//     ]
+//   },
+//   plugins: [new CleanWebpackPlugin(['lib'])]
+// },
+ {
+  entry: './index_for_react_app.js',
   externals: {
     react: {
       root: 'React',

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -3,12 +3,13 @@
 const path = require('path');
 // eslint-disable-next-line import/no-extraneous-dependencies
 const CleanWebpackPlugin = require('clean-webpack-plugin');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const { version } = require('./package.json');
 
 module.exports = [
 //   {
 //   // entry: ['babel-polyfill', './index.js'],
-//   entry: './index_for_react_app.js',
+//   entry: './umd.js',
 //   output: {
 //     path: path.join(__dirname, '/lib'),
 //     filename: 'index.js',
@@ -109,7 +110,8 @@ module.exports = [
       {
         test: /\.scss$/,
         use: [
-          { loader: 'style-loader' },
+          { loader: MiniCssExtractPlugin.loader },
+          // { loader: 'style-loader' },
           { loader: 'css-loader' },
           {
             loader: 'sass-loader',
@@ -121,7 +123,9 @@ module.exports = [
       },
       {
         test: /\.css$/,
-        use: ['style-loader', 'css-loader']
+        use: [MiniCssExtractPlugin.loader, 
+          // 'style-loader',
+           'css-loader']
       },
       {
         test: /\.(jpg|png|gif|svg|woff|ttf|eot)$/,
@@ -131,6 +135,6 @@ module.exports = [
       }
     ]
   },
-  plugins: [new CleanWebpackPlugin(['module'])]
+  plugins: [new MiniCssExtractPlugin(),new CleanWebpackPlugin(['module'])]
 }
 ];


### PR DESCRIPTION
- change webpack output to be react-lib, instead of version with `selfMount`;
- remove `style-loader`, add `mini-css-extract-plugin` to bundle styles into a single .css file, instead of auto-injecting into HTML;
- change version to `1.1.0`;
- remove husky.